### PR TITLE
FIX for issue #19 - Adds memory release option

### DIFF
--- a/sidetable/sidetable.py
+++ b/sidetable/sidetable.py
@@ -4,6 +4,7 @@ import pandas as pd
 from pandas.api.types import is_numeric_dtype
 from functools import reduce
 import warnings
+import weakref
 
 
 @pd.api.extensions.register_dataframe_accessor("stb")
@@ -15,8 +16,15 @@ class SideTableAccessor:
     SORT_FLAG = '~~~~zz'
 
     def __init__(self, pandas_obj):
+        self._finalizer = weakref.finalize(self, self._cleanup)
         self._validate(pandas_obj)
         self._obj = pandas_obj
+
+    def _cleanup(self):
+        del self._obj
+
+    def remove(self):
+        self._finalizer()
 
     @staticmethod
     def _validate(obj):


### PR DESCRIPTION
This fix makes it possible to release memory, which is critical when dealing with large datasets.

It adds a "remove" method to free the memory.
Use it ONLY at the end of your work, when you're done using Sitetable with that specific dataframe because it removes the accessor. The accessor is still available for use with other dataframe variables.

Use as follows (Same example as the one I used to explain the issue):

```
import pandas as pd
import sidetable

# loading a 1.2GB data file.
df0 = pd.read_parquet('US_Accidents_June20.parquet')

# extacting frequency stats
column_name = df0.columns[1]
df2 = df0.stb.freq([column_name])

# deleting dataframes objects
df0.stb.remove()  #### this releases the memory used by df0 variable ########

del df2
del df0

# memory ==> a few MB 
```